### PR TITLE
Add browser-based FitBit OAuth and basic activity summary retrieval

### DIFF
--- a/App/Config/AppConfig.js
+++ b/App/Config/AppConfig.js
@@ -1,0 +1,8 @@
+module.exports = {
+  // FitBit
+  FITBIT_APP_ID: '2282DH',
+  FITBIT_CALLBACK_URI: 'fitcat%3A%2F%2Foauth-callback',
+  FITBIT_SCOPE: 'activity%20heartrate%20location%20nutrition%20profile%20settings%20sleep%20social%20weight',
+  FITBIT_EXPIRATION: 60 * 60 * 24 * 365, // 1 year - default value, user-changeable during auth
+  FITBIT_STATE: Math.ceil(Math.random() * 10000) // TODO: look into this field more (security-related)
+}

--- a/App/Config/StorageKeys.js
+++ b/App/Config/StorageKeys.js
@@ -1,0 +1,4 @@
+module.exports = {
+  FITBIT_ACCESS_TOKEN: 'fitbit_access_token',
+  FITBIT_USER_ID: 'fitbit_user_id'
+}

--- a/App/Containers/App.js
+++ b/App/Containers/App.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react'
+import { Platform, Linking } from 'react-native'
 import { Provider } from 'react-redux'
 import RootContainer from './RootContainer'
 import createStore from '../Redux'
 import DebugSettings from '../Config/DebugSettings'
+import { Actions as NavigationActions } from 'react-native-router-flux'
 import '../I18n/I18n'
 
 if (__DEV__) {
@@ -24,6 +26,35 @@ const store = createStore()
  * We separate like this to play nice with React Native's hot reloading.
  */
 class App extends Component {
+  componentDidMount () {
+    if (Platform.OS === 'ios') {
+      // Event listeners only work on iOS apparently
+      Linking.addEventListener('url', this.handleDeepLink)
+    } else {
+      Linking.getInitialURL().then(url => {
+        if (url) {
+          const route = url.replace(/.*?:\/\//g, '')
+          console.log(route)
+
+          // TODO
+          NavigationActions.deviceInfo()
+        }
+      })
+    }
+  }
+
+  componentWillUnmount () {
+    Linking.removeEventListener('url', this.handleDeepLink)
+  }
+
+  handleDeepLink (e) {
+    const route = e.url.replace(/.*?:\/\//g, '')
+    console.log(route)
+
+    // TODO
+    NavigationActions.deviceInfo()
+  }
+
   render () {
     return (
       <Provider store={store}>

--- a/App/Containers/App.js
+++ b/App/Containers/App.js
@@ -29,7 +29,7 @@ class App extends Component {
   componentDidMount () {
     if (Platform.OS === 'ios') {
       // Event listeners only work on iOS apparently
-      Linking.addEventListener('url', this.handleDeepLinkIOS)
+      Linking.addEventListener('url', this.handleDeepLinkIOS.bind(this))
     } else {
       // TODO: Handle promise rejection where url = null (i.e. launching the app normally)
       Linking.getInitialURL().then(url => {

--- a/App/Containers/FitbitStatsScreen.js
+++ b/App/Containers/FitbitStatsScreen.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { AsyncStorage, Alert, ScrollView, View, TextInput, Image } from 'react-native'
+import { Images } from '../Themes'
+import { default as StorageKeys } from '../Config/StorageKeys'
+
+// Styles
+import styles from './Styles/APITestingScreenStyle'
+
+export default class FitbitStatsScreen extends React.Component {
+
+  constructor (props) {
+    super(props)
+
+    this.getDailyActivitySummary()
+  }
+
+  async getDailyActivitySummary () {
+    let userId = await AsyncStorage.getItem(StorageKeys.FITBIT_USER_ID)
+    let accessToken = await AsyncStorage.getItem(StorageKeys.FITBIT_ACCESS_TOKEN)
+
+    // TODO: Improve a lot
+    fetch(`https://api.fitbit.com/1/user/${userId}/activities/date/${new Date().toISOString().slice(0, 10)}.json`, {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + accessToken
+      }
+    }).then((response) => response.json())
+      .then((responseJson) => {
+        console.info(responseJson)
+        Alert.alert(JSON.stringify(responseJson.summary))
+      })
+  }
+
+  render () {
+    return (
+      <View style={styles.mainContainer}>
+        <Image source={Images.background} style={styles.backgroundImage} resizeMode='stretch' />
+        <ScrollView style={styles.container} ref='container'>
+
+          <View style={styles.section}>
+            <TextInput style={styles.sectionText} editable={false} defaultValue='No data' ref='result' />
+          </View>
+        </ScrollView>
+      </View>
+    )
+  }
+}

--- a/App/Containers/PresentationScreen.js
+++ b/App/Containers/PresentationScreen.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import { ScrollView, Text, Image, View } from 'react-native'
 import { Images } from '../Themes'
-// import RoundedButton from '../Components/RoundedButton'
+import RoundedButton from '../Components/RoundedButton'
 // import { Actions as NavigationActions } from 'react-native-router-flux'
+import { default as OAuthManager } from '../Services/OAuthManager'
 
 // Styles
 import styles from './Styles/PresentationScreenStyle'
@@ -23,6 +24,10 @@ export default class PresentationScreen extends React.Component {
               Ignite provided the basis of what is here!
             </Text>
           </View>
+
+          <RoundedButton onPress={OAuthManager.authorizeFitbitAccount}>
+            Connect FitBit Account
+          </RoundedButton>
 
           {/* <RoundedButton onPress={NavigationActions.componentExamples}>
             Component Examples Screen

--- a/App/Navigation/NavigationRouter.js
+++ b/App/Navigation/NavigationRouter.js
@@ -16,6 +16,7 @@ import MapviewExample from '../Containers/MapviewExample'
 import APITestingScreen from '../Containers/APITestingScreen'
 import ThemeScreen from '../Containers/ThemeScreen'
 import DeviceInfoScreen from '../Containers/DeviceInfoScreen'
+import FitbitStatsScreen from '../Containers/FitbitStatsScreen'
 
 /* **************************
 * Documentation: https://github.com/aksonov/react-native-router-flux
@@ -38,6 +39,7 @@ class NavigationRouter extends Component {
             <Scene key='apiTesting' component={APITestingScreen} title='API Testing' />
             <Scene key='theme' component={ThemeScreen} title='Theme' />
             <Scene key='deviceInfo' component={DeviceInfoScreen} title='Device Info' />
+            <Scene key='fitbitStats' component={FitbitStatsScreen} title='Activity Summary' />
           </Scene>
         </Scene>
       </Router>

--- a/App/Services/OAuthManager.js
+++ b/App/Services/OAuthManager.js
@@ -1,0 +1,26 @@
+import { Linking } from 'react-native'
+import { default as config } from '../../config.js'
+
+export default {
+
+  /**
+   * Launches a browser to authenticate with FitBit. After authorization, the app will
+   * be redirected to wherever redirect_uri says so, which we pick up over in App.js
+   * before processing in parseFitbitAuthResponse below.
+   */
+  authorizeFitbitAccount: () => {
+    let fitbitAuthUrl = `https://www.fitbit.com/oauth2/authorize?response_type=token` +
+      `&client_id=${config.fitbit_app_id}` +
+      `&redirect_uri=${config.fitbit_callback_uri}` +
+      `&scope=${config.fitbit_scope}` +
+      `&expires_in=${config.fitbit_expiration}` +
+      `&state=${config.fitbit_state}`
+
+    Linking.openURL(fitbitAuthUrl).catch(err => console.err('An error occurred', err))
+  },
+
+  parseFitbitAuthResponse: (responseData) => {
+    console.info(responseData)
+  }
+
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,13 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="fitcat"
+                  android:host="oauth-callback" />
+        </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>

--- a/config.js
+++ b/config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  // FitBit
+  fitbit_app_id: '2282DH',
+  fitbit_callback_uri: 'fitcat%3A%2F%2Foauth-callback',
+  fitbit_scope: 'activity%20heartrate%20location%20nutrition%20profile%20settings%20sleep%20social%20weight',
+  fitbit_expiration: 60 * 60 * 24 * 365, // 1 year - default value, user-changeable during auth
+  fitbit_state: Math.ceil(Math.random() * 10000) // TODO: look into this field more (security-related)
+}

--- a/config.js
+++ b/config.js
@@ -1,8 +1,0 @@
-module.exports = {
-  // FitBit
-  fitbit_app_id: '2282DH',
-  fitbit_callback_uri: 'fitcat%3A%2F%2Foauth-callback',
-  fitbit_scope: 'activity%20heartrate%20location%20nutrition%20profile%20settings%20sleep%20social%20weight',
-  fitbit_expiration: 60 * 60 * 24 * 365, // 1 year - default value, user-changeable during auth
-  fitbit_state: Math.ceil(Math.random() * 10000) // TODO: look into this field more (security-related)
-}

--- a/ios/FitCat.xcodeproj/project.pbxproj
+++ b/ios/FitCat.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -21,20 +22,20 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
-		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
-		7894D65D3BE84D18B532EBFC /* libReactNativeConfig.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FE598709E91474589B27DFD /* libReactNativeConfig.a */; };
-		2E0508DDB368400FB0A72DF5 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD859BC497A4E60A18ED9C8 /* libRNDeviceInfo.a */; };
 		151DEFEF1122461EA7BCF9B2 /* libRNI18n.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6755FF5F43E24AD1BF7684F3 /* libRNI18n.a */; };
-		ACD33EED91814EED8E0F83F9 /* libAirMaps.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 866E46469CAB403780B87EB5 /* libAirMaps.a */; };
+		2E0508DDB368400FB0A72DF5 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BDD859BC497A4E60A18ED9C8 /* libRNDeviceInfo.a */; };
 		3DB5E99107A345F09B47312F /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C8AA8FD390DF47F198BA192A /* libRNVectorIcons.a */; };
-		F484C8C298EA4A81AF332F4C /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8C77B1AC8B0E4AC1A3221792 /* Entypo.ttf */; };
-		EF3F072B9267415A8D16542D /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C13962579B00451C84201BDE /* EvilIcons.ttf */; };
-		AA62E13B4FF64ACB88CD21CF /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0C269B357BE04B2D9D242D1D /* FontAwesome.ttf */; };
-		B092E0A102874A0E8803D7FD /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6CCF90561A0E459FB83EADC0 /* Foundation.ttf */; };
-		7DD903EF1BEF4FD7AA9754ED /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 99F4E3320B4A47769641B40E /* Ionicons.ttf */; };
 		71A6CC115432408482FD67C3 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4011ABC84204E9BB3425F96 /* MaterialIcons.ttf */; };
+		7894D65D3BE84D18B532EBFC /* libReactNativeConfig.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FE598709E91474589B27DFD /* libReactNativeConfig.a */; };
+		7DD903EF1BEF4FD7AA9754ED /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 99F4E3320B4A47769641B40E /* Ionicons.ttf */; };
+		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		AA62E13B4FF64ACB88CD21CF /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0C269B357BE04B2D9D242D1D /* FontAwesome.ttf */; };
+		ACD33EED91814EED8E0F83F9 /* libAirMaps.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 866E46469CAB403780B87EB5 /* libAirMaps.a */; };
+		B092E0A102874A0E8803D7FD /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6CCF90561A0E459FB83EADC0 /* Foundation.ttf */; };
 		EC5EFD64472B484E82DB1767 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D9113BC3A8CE4BBEBF75A1A9 /* Octicons.ttf */; };
+		EF3F072B9267415A8D16542D /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C13962579B00451C84201BDE /* EvilIcons.ttf */; };
 		F3D5195AF1474BA59F728347 /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 2838427FAAE1435D8A3CE7A8 /* Zocial.ttf */; };
+		F484C8C298EA4A81AF332F4C /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8C77B1AC8B0E4AC1A3221792 /* Entypo.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -101,6 +102,48 @@
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
 		};
+		3C43B51C1DAD859B003D65DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9A7CA0EA5A77429BA49DC953 /* AirMaps.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 11FA5C511C4A1296003AC2EE;
+			remoteInfo = AirMaps;
+		};
+		3C43B5291DAD859B003D65DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4A86ECD71FFD49EE848E12B1 /* ReactNativeConfig.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = EB2648DF1C7BE17A00B8F155;
+			remoteInfo = ReactNativeConfig;
+		};
+		3C43B52C1DAD859B003D65DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F54DBDEB6E7640958661128C /* RNDeviceInfo.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = DA5891D81BA9A9FC002B4DB2;
+			remoteInfo = RNDeviceInfo;
+		};
+		3C43B5301DAD859B003D65DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7253B74A673748A7ADE481E7 /* RNI18n.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CDD7BF781B2D5125006FDA75;
+			remoteInfo = RNI18n;
+		};
+		3C43B5321DAD859B003D65DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7253B74A673748A7ADE481E7 /* RNI18n.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CDD7BF831B2D5126006FDA75;
+			remoteInfo = RNI18nTests;
+		};
+		3C43B5351DAD859B003D65DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EEB798E25B554B34969FACBF /* RNVectorIcons.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 5DBEB1501B18CEA900B34395;
+			remoteInfo = RNVectorIcons;
+		};
 		78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */;
@@ -118,17 +161,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = main.jsbundle; path = main.jsbundle; sourceTree = "<group>"; };
-		00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTActionSheet.xcodeproj; path = ../node_modules/react-native/Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj; sourceTree = "<group>"; };
-		00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTGeolocation.xcodeproj; path = ../node_modules/react-native/Libraries/Geolocation/RCTGeolocation.xcodeproj; sourceTree = "<group>"; };
-		00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTImage.xcodeproj; path = ../node_modules/react-native/Libraries/Image/RCTImage.xcodeproj; sourceTree = "<group>"; };
-		00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTNetwork.xcodeproj; path = ../node_modules/react-native/Libraries/Network/RCTNetwork.xcodeproj; sourceTree = "<group>"; };
-		00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = ../node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj; sourceTree = "<group>"; };
+		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTActionSheet.xcodeproj; path = "../node_modules/react-native/Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj"; sourceTree = "<group>"; };
+		00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTGeolocation.xcodeproj; path = "../node_modules/react-native/Libraries/Geolocation/RCTGeolocation.xcodeproj"; sourceTree = "<group>"; };
+		00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTImage.xcodeproj; path = "../node_modules/react-native/Libraries/Image/RCTImage.xcodeproj"; sourceTree = "<group>"; };
+		00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTNetwork.xcodeproj; path = "../node_modules/react-native/Libraries/Network/RCTNetwork.xcodeproj"; sourceTree = "<group>"; };
+		00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = "../node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj"; sourceTree = "<group>"; };
 		00E356EE1AD99517003FC87E /* FitCatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FitCatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* FitCatTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FitCatTests.m; sourceTree = "<group>"; };
-		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = ../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj; sourceTree = "<group>"; };
-		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = ../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj; sourceTree = "<group>"; };
+		0C269B357BE04B2D9D242D1D /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
+		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
+		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* FitCat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FitCat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = FitCat/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = FitCat/AppDelegate.m; sourceTree = "<group>"; };
@@ -136,27 +180,26 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = FitCat/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = FitCat/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = FitCat/main.m; sourceTree = "<group>"; };
-		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = ../node_modules/react-native/React/React.xcodeproj; sourceTree = "<group>"; };
-		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = ../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj; sourceTree = "<group>"; };
-		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = ../node_modules/react-native/Libraries/Text/RCTText.xcodeproj; sourceTree = "<group>"; };
-		4A86ECD71FFD49EE848E12B1 /* ReactNativeConfig.xcodeproj */ = {isa = PBXFileReference; name = "ReactNativeConfig.xcodeproj"; path = "../node_modules/react-native-config/ios/ReactNativeConfig.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		3FE598709E91474589B27DFD /* libReactNativeConfig.a */ = {isa = PBXFileReference; name = "libReactNativeConfig.a"; path = "libReactNativeConfig.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		F54DBDEB6E7640958661128C /* RNDeviceInfo.xcodeproj */ = {isa = PBXFileReference; name = "RNDeviceInfo.xcodeproj"; path = "../node_modules/react-native-device-info/RNDeviceInfo.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		BDD859BC497A4E60A18ED9C8 /* libRNDeviceInfo.a */ = {isa = PBXFileReference; name = "libRNDeviceInfo.a"; path = "libRNDeviceInfo.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		7253B74A673748A7ADE481E7 /* RNI18n.xcodeproj */ = {isa = PBXFileReference; name = "RNI18n.xcodeproj"; path = "../node_modules/react-native-i18n/RNI18n.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		6755FF5F43E24AD1BF7684F3 /* libRNI18n.a */ = {isa = PBXFileReference; name = "libRNI18n.a"; path = "libRNI18n.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		9A7CA0EA5A77429BA49DC953 /* AirMaps.xcodeproj */ = {isa = PBXFileReference; name = "AirMaps.xcodeproj"; path = "../node_modules/react-native-maps/ios/AirMaps.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		866E46469CAB403780B87EB5 /* libAirMaps.a */ = {isa = PBXFileReference; name = "libAirMaps.a"; path = "libAirMaps.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		EEB798E25B554B34969FACBF /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; name = "RNVectorIcons.xcodeproj"; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		C8AA8FD390DF47F198BA192A /* libRNVectorIcons.a */ = {isa = PBXFileReference; name = "libRNVectorIcons.a"; path = "libRNVectorIcons.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		8C77B1AC8B0E4AC1A3221792 /* Entypo.ttf */ = {isa = PBXFileReference; name = "Entypo.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		C13962579B00451C84201BDE /* EvilIcons.ttf */ = {isa = PBXFileReference; name = "EvilIcons.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		0C269B357BE04B2D9D242D1D /* FontAwesome.ttf */ = {isa = PBXFileReference; name = "FontAwesome.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		6CCF90561A0E459FB83EADC0 /* Foundation.ttf */ = {isa = PBXFileReference; name = "Foundation.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		99F4E3320B4A47769641B40E /* Ionicons.ttf */ = {isa = PBXFileReference; name = "Ionicons.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		E4011ABC84204E9BB3425F96 /* MaterialIcons.ttf */ = {isa = PBXFileReference; name = "MaterialIcons.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		D9113BC3A8CE4BBEBF75A1A9 /* Octicons.ttf */ = {isa = PBXFileReference; name = "Octicons.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		2838427FAAE1435D8A3CE7A8 /* Zocial.ttf */ = {isa = PBXFileReference; name = "Zocial.ttf"; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		2838427FAAE1435D8A3CE7A8 /* Zocial.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Zocial.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; };
+		3FE598709E91474589B27DFD /* libReactNativeConfig.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libReactNativeConfig.a; sourceTree = "<group>"; };
+		4A86ECD71FFD49EE848E12B1 /* ReactNativeConfig.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = ReactNativeConfig.xcodeproj; path = "../node_modules/react-native-config/ios/ReactNativeConfig.xcodeproj"; sourceTree = "<group>"; };
+		6755FF5F43E24AD1BF7684F3 /* libRNI18n.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNI18n.a; sourceTree = "<group>"; };
+		6CCF90561A0E459FB83EADC0 /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
+		7253B74A673748A7ADE481E7 /* RNI18n.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNI18n.xcodeproj; path = "../node_modules/react-native-i18n/RNI18n.xcodeproj"; sourceTree = "<group>"; };
+		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
+		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		866E46469CAB403780B87EB5 /* libAirMaps.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libAirMaps.a; sourceTree = "<group>"; };
+		8C77B1AC8B0E4AC1A3221792 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
+		99F4E3320B4A47769641B40E /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
+		9A7CA0EA5A77429BA49DC953 /* AirMaps.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = AirMaps.xcodeproj; path = "../node_modules/react-native-maps/ios/AirMaps.xcodeproj"; sourceTree = "<group>"; };
+		BDD859BC497A4E60A18ED9C8 /* libRNDeviceInfo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNDeviceInfo.a; sourceTree = "<group>"; };
+		C13962579B00451C84201BDE /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
+		C8AA8FD390DF47F198BA192A /* libRNVectorIcons.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNVectorIcons.a; sourceTree = "<group>"; };
+		D9113BC3A8CE4BBEBF75A1A9 /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
+		E4011ABC84204E9BB3425F96 /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
+		EEB798E25B554B34969FACBF /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
+		F54DBDEB6E7640958661128C /* RNDeviceInfo.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNDeviceInfo.xcodeproj; path = "../node_modules/react-native-device-info/RNDeviceInfo.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -250,6 +293,21 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		0CD701A0FA78442FBB889DDB /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				8C77B1AC8B0E4AC1A3221792 /* Entypo.ttf */,
+				C13962579B00451C84201BDE /* EvilIcons.ttf */,
+				0C269B357BE04B2D9D242D1D /* FontAwesome.ttf */,
+				6CCF90561A0E459FB83EADC0 /* Foundation.ttf */,
+				99F4E3320B4A47769641B40E /* Ionicons.ttf */,
+				E4011ABC84204E9BB3425F96 /* MaterialIcons.ttf */,
+				D9113BC3A8CE4BBEBF75A1A9 /* Octicons.ttf */,
+				2838427FAAE1435D8A3CE7A8 /* Zocial.ttf */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
 		139105B71AF99BAD00B5F7CC /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -284,6 +342,47 @@
 			isa = PBXGroup;
 			children = (
 				146834041AC3E56700842450 /* libReact.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3C43B5111DAD859B003D65DF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3C43B52A1DAD859B003D65DF /* libReactNativeConfig.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3C43B5131DAD859B003D65DF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3C43B5361DAD859B003D65DF /* libRNVectorIcons.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3C43B5151DAD859B003D65DF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3C43B52D1DAD859B003D65DF /* libRNDeviceInfo.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3C43B5171DAD859B003D65DF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3C43B5311DAD859B003D65DF /* libRNI18n.a */,
+				3C43B5331DAD859B003D65DF /* RNI18nTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3C43B5191DAD859B003D65DF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3C43B51D1DAD859B003D65DF /* libAirMaps.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -346,22 +445,6 @@
 				00E356EE1AD99517003FC87E /* FitCatTests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		0CD701A0FA78442FBB889DDB /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				8C77B1AC8B0E4AC1A3221792 /* Entypo.ttf */,
-				C13962579B00451C84201BDE /* EvilIcons.ttf */,
-				0C269B357BE04B2D9D242D1D /* FontAwesome.ttf */,
-				6CCF90561A0E459FB83EADC0 /* Foundation.ttf */,
-				99F4E3320B4A47769641B40E /* Ionicons.ttf */,
-				E4011ABC84204E9BB3425F96 /* MaterialIcons.ttf */,
-				D9113BC3A8CE4BBEBF75A1A9 /* Octicons.ttf */,
-				2838427FAAE1435D8A3CE7A8 /* Zocial.ttf */,
-			);
-			name = Resources;
-			path = "";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -431,6 +514,10 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
+					ProductGroup = 3C43B5191DAD859B003D65DF /* Products */;
+					ProjectRef = 9A7CA0EA5A77429BA49DC953 /* AirMaps.xcodeproj */;
+				},
+				{
 					ProductGroup = 00C302A81ABCB8CE00DB3ED1 /* Products */;
 					ProjectRef = 00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */;
 				},
@@ -469,6 +556,22 @@
 				{
 					ProductGroup = 146834001AC3E56700842450 /* Products */;
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+				},
+				{
+					ProductGroup = 3C43B5111DAD859B003D65DF /* Products */;
+					ProjectRef = 4A86ECD71FFD49EE848E12B1 /* ReactNativeConfig.xcodeproj */;
+				},
+				{
+					ProductGroup = 3C43B5151DAD859B003D65DF /* Products */;
+					ProjectRef = F54DBDEB6E7640958661128C /* RNDeviceInfo.xcodeproj */;
+				},
+				{
+					ProductGroup = 3C43B5171DAD859B003D65DF /* Products */;
+					ProjectRef = 7253B74A673748A7ADE481E7 /* RNI18n.xcodeproj */;
+				},
+				{
+					ProductGroup = 3C43B5131DAD859B003D65DF /* Products */;
+					ProjectRef = EEB798E25B554B34969FACBF /* RNVectorIcons.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -536,6 +639,48 @@
 			remoteRef = 146834031AC3E56700842450 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		3C43B51D1DAD859B003D65DF /* libAirMaps.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libAirMaps.a;
+			remoteRef = 3C43B51C1DAD859B003D65DF /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3C43B52A1DAD859B003D65DF /* libReactNativeConfig.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libReactNativeConfig.a;
+			remoteRef = 3C43B5291DAD859B003D65DF /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3C43B52D1DAD859B003D65DF /* libRNDeviceInfo.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNDeviceInfo.a;
+			remoteRef = 3C43B52C1DAD859B003D65DF /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3C43B5311DAD859B003D65DF /* libRNI18n.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNI18n.a;
+			remoteRef = 3C43B5301DAD859B003D65DF /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3C43B5331DAD859B003D65DF /* RNI18nTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = RNI18nTests.xctest;
+			remoteRef = 3C43B5321DAD859B003D65DF /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3C43B5361DAD859B003D65DF /* libRNVectorIcons.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNVectorIcons.a;
+			remoteRef = 3C43B5351DAD859B003D65DF /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		78C398B91ACF4ADC00677621 /* libRCTLinking.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -593,7 +738,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
-			showEnvVarsInLog = 1;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -649,8 +793,6 @@
 				INFOPLIST_FILE = FitCatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FitCat.app/FitCat";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -659,6 +801,8 @@
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FitCat.app/FitCat";
 			};
 			name = Debug;
 		};
@@ -670,8 +814,6 @@
 				INFOPLIST_FILE = FitCatTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FitCat.app/FitCat";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
@@ -680,6 +822,8 @@
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FitCat.app/FitCat";
 			};
 			name = Release;
 		};
@@ -692,13 +836,13 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)\..\node_modules\react-native-config\ios\ReactNativeConfig",
-					"$(SRCROOT)\..\node_modules\react-native-device-info\RNDeviceInfo",
-					"$(SRCROOT)\..\node_modules\react-native-i18n\RNI18n",
-					"$(SRCROOT)\..\node_modules\react-native-maps\ios\AirMaps/**",
-					"$(SRCROOT)\..\node_modules\react-native-vector-icons\RNVectorIconsManager",
+					"$(SRCROOT)..\node_modules\neact-native-configiosReactNativeConfig",
+					"$(SRCROOT)..\node_modules\neact-native-device-infoRNDeviceInfo",
+					"$(SRCROOT)..\node_modules\neact-native-i18nRNI18n",
+					"$(SRCROOT)..\node_modules\neact-native-mapsiosAirMaps/**",
+					"$(SRCROOT)..\node_modules\neact-native-vector-iconsRNVectorIconsManager",
 				);
-				INFOPLIST_FILE = "FitCat/Info.plist";
+				INFOPLIST_FILE = FitCat/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -717,13 +861,13 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)\..\node_modules\react-native-config\ios\ReactNativeConfig",
-					"$(SRCROOT)\..\node_modules\react-native-device-info\RNDeviceInfo",
-					"$(SRCROOT)\..\node_modules\react-native-i18n\RNI18n",
-					"$(SRCROOT)\..\node_modules\react-native-maps\ios\AirMaps/**",
-					"$(SRCROOT)\..\node_modules\react-native-vector-icons\RNVectorIconsManager",
+					"$(SRCROOT)..\node_modules\neact-native-configiosReactNativeConfig",
+					"$(SRCROOT)..\node_modules\neact-native-device-infoRNDeviceInfo",
+					"$(SRCROOT)..\node_modules\neact-native-i18nRNI18n",
+					"$(SRCROOT)..\node_modules\neact-native-mapsiosAirMaps/**",
+					"$(SRCROOT)..\node_modules\neact-native-vector-iconsRNVectorIconsManager",
 				);
-				INFOPLIST_FILE = "FitCat/Info.plist";
+				INFOPLIST_FILE = FitCat/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -772,11 +916,22 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)\..\node_modules\react-native-config\ios\ReactNativeConfig",
-					"$(SRCROOT)\..\node_modules\react-native-device-info\RNDeviceInfo",
-					"$(SRCROOT)\..\node_modules\react-native-i18n\RNI18n",
-					"$(SRCROOT)\..\node_modules\react-native-maps\ios\AirMaps/**",
-					"$(SRCROOT)\..\node_modules\react-native-vector-icons\RNVectorIconsManager",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-configiosReactNativeConfig",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-device-infoRNDeviceInfo",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-i18nRNI18n",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-mapsiosAirMaps/**",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-vector-iconsRNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native/Libraries/LinkingIOS",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -817,11 +972,22 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)\..\node_modules\react-native-config\ios\ReactNativeConfig",
-					"$(SRCROOT)\..\node_modules\react-native-device-info\RNDeviceInfo",
-					"$(SRCROOT)\..\node_modules\react-native-i18n\RNI18n",
-					"$(SRCROOT)\..\node_modules\react-native-maps\ios\AirMaps/**",
-					"$(SRCROOT)\..\node_modules\react-native-vector-icons\RNVectorIconsManager",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-configiosReactNativeConfig",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-device-infoRNDeviceInfo",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-i18nRNI18n",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-mapsiosAirMaps/**",
+					"$(SRCROOT)..",
+					ode_modules,
+					"eact-native-vector-iconsRNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native/Libraries/LinkingIOS",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/ios/FitCat/AppDelegate.m
+++ b/ios/FitCat/AppDelegate.m
@@ -10,6 +10,7 @@
 #import "AppDelegate.h"
 
 #import "RCTBundleURLProvider.h"
+#import "RCTLinkingManager.h"
 #import "RCTRootView.h"
 
 @implementation AppDelegate
@@ -33,5 +34,12 @@
   [self.window makeKeyAndVisible];
   return YES;
 }
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
+  sourceApplication:(nullable NSString *)sourceApplication annotation:(nonnull id)annotation
+{
+  return [RCTLinkingManager application:application openURL:url sourceApplication:sourceApplication annotation:annotation];
+}
+
 
 @end

--- a/ios/FitCat/Info.plist
+++ b/ios/FitCat/Info.plist
@@ -20,6 +20,17 @@
     <string>????</string>
     <key>CFBundleVersion</key>
     <string>1</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleTypeRole</key>
+        <string>Editor</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>fitcat</string>
+        </array>
+      </dict>
+    </array>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>UILaunchStoryboardName</key>


### PR DESCRIPTION
- Adds `fitcat://` URI scheme for OAuth callback (`fitcat://oauth-callback` is where the app is returned to after auth)
- Can authenticate the app with the user's FitBit account (currently via an external browser instead of Chrome Custom Tabs/iOS equivalent)
- Displays user activity summary in an alert
