### PR TITLE
Set colour for status bar and Chrome Tabs

### DIFF
--- a/App/Containers/RootContainer.js
+++ b/App/Containers/RootContainer.js
@@ -4,6 +4,7 @@ import NavigationRouter from '../Navigation/NavigationRouter'
 import { connect } from 'react-redux'
 import StartupActions from '../Redux/StartupRedux'
 import ReduxPersist from '../Config/ReduxPersist'
+import { Colors } from '../Themes/'
 // import './Config/PushConfig'
 
 // Styles
@@ -20,7 +21,7 @@ class RootContainer extends Component {
   render () {
     return (
       <View style={styles.applicationView}>
-        <StatusBar barStyle='light-content' />
+        <StatusBar barStyle='light-content' backgroundColor={Colors.mainText} />
         <NavigationRouter />
       </View>
     )

--- a/App/Services/OAuthManager.js
+++ b/App/Services/OAuthManager.js
@@ -1,7 +1,8 @@
-import { AsyncStorage, Platform, Linking } from 'react-native'
+import { AsyncStorage, Platform, Linking, StatusBar } from 'react-native'
 import { Actions as NavigationActions } from 'react-native-router-flux'
 import SafariView from 'react-native-safari-view'
-import { CustomTabs } from 'react-native-custom-tabs'
+import { CustomTabs, ANIMATIONS_SLIDE } from 'react-native-custom-tabs'
+import { Colors } from '../Themes/'
 import { default as AppConfig } from '../Config/AppConfig'
 import { default as StorageKeys } from '../Config/StorageKeys'
 
@@ -60,7 +61,12 @@ module.exports = {
    */
   openLinkChromeTabs: (url) => {
     CustomTabs.openURL(
-      url
+      url,
+      {
+        toolbarColor: Colors.navigation,
+        showPageTitle: true,
+        animations: ANIMATIONS_SLIDE
+      }
     ).catch(error => {
       console.error(error)
       module.exports.openLinkExternally(url)


### PR DESCRIPTION
Fixes the system status bar being black on Android by making it the darker blue colour we use for text, and applies the same for the in-app browser used for FitBit. It does not fix the status bar turning grey after authenticating with FitBit, however.