### PR TITLE
Fix for ios not liking anything that isn't HTTPS

### DIFF
--- a/ios/FitCat/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/FitCat/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/ios/FitCat/Info.plist
+++ b/ios/FitCat/Info.plist
@@ -35,14 +35,8 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>


### PR DESCRIPTION
1. Not the end of the world if we leave this flag. Apple does accept applications with it on.
2. We SHOULD use the exception list, but it was not working when I was trying to get it, but this does. So for now I think it's fine. 