### PR TITLE
Send step data to WellCat when viewing dashboard

### DIFF
--- a/App/Containers/Dashboard.js
+++ b/App/Containers/Dashboard.js
@@ -95,6 +95,12 @@ export default class Dashboard extends React.Component {
         steps: responseJson.summary.steps,
         distance: responseJson.summary.distances[0].distance
       })
+
+      // We're doing this on the dashboard because the WellCat API does not appear
+      // to support sending data in bulk, so it would have to be individual requests
+      // for each day to send historical data. We also cannot assume the user will
+      // go to the steps page, so it doesn't make total sense to do it there.
+      WellCatManager.updateSteps(responseJson.summary.steps)
     })
 
     fetch(`https://api.fitbit.com/1/user/-/sleep/date/${date}.json`, {

--- a/App/Services/WellCatManager.js
+++ b/App/Services/WellCatManager.js
@@ -215,6 +215,31 @@ module.exports = {
     })
   },
 
+  async updateSteps (steps) {
+    let catId = await AsyncStorage.getItem(StorageKeys.CAT_ID)
+    let wellcatUpdateStepsUrl = `${AppConfig.WELLCAT_BASE}/fitcat/steps`
+
+    return fetch(wellcatUpdateStepsUrl, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        'petID': catId,
+        'steps': steps,
+        'date': Moment().format('YYYY[-]MM[-]DD')
+      })
+    }).then((response) => {
+      if (response.ok) {
+        return
+      }
+    }).catch((error) => {
+      console.log(error)
+      return { code: -1, content: error }
+    })
+  },
+
   addCat: async (cat) => {
     let wellcatUrl = `${AppConfig.WELLCAT_BASE}/fitcat/register`
 


### PR DESCRIPTION
Since we're no longer obtaining data, I had to adjust the date to a day that had data to test (I used 2016-11-25). I used pet id 10, so `/fitcat/view/10` now looks like:

```
{
  "success": true,
  "pet": {
    "name": "Dog",
    "breed": 3,
    "gender": 1,
    "dateofbirth": "2016-01-01",
    "weight": "10",
    "height": "10",
    "length": "18",
    "declawed": false,
    "outdoor": false,
    "fixed": false,
    "lastupdated": "2016-12-09 06:42:09.568186"
  },
  "fitcat": [
    [...]
    {
      "weight": null,
      "steps": 2326,
      "waterconsumption": null,
      "foodconsumption": null,
      "foodbrand": null,
      "description": null,
      "name": null,
      "date": "2016-11-25"
    },
    [...]
  ]
}
```